### PR TITLE
Populate locals, and extract html_options

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -6,7 +6,8 @@ module Futurism
       if records_or_string.is_a?(ActiveRecord::Base) || records_or_string.is_a?(ActiveRecord::Relation)
         futurize_active_record(records_or_string, extends: extends, placeholder: placeholder, **options)
       elsif records_or_string.is_a?(String)
-        futurize_with_options(extends: extends, placeholder: placeholder, partial: records_or_string, **options)
+        html_options = options.delete(:html_options)
+        futurize_with_options(extends: extends, placeholder: placeholder, partial: records_or_string, locals: options, html_options: html_options)
       else
         futurize_with_options(extends: extends, placeholder: placeholder, **options)
       end

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -70,6 +70,18 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post: post})
   end
 
+  test "broadcasts a rendered partial after receiving the shorthand syntax with html options" do
+    renderer_spy = Spy.on(ApplicationController, :render)
+    post = Post.create title: "Lorem"
+    fragment = Nokogiri::HTML.fragment(futurize("posts/card", post: post, extends: :div, html_options: {style: "color: green"}) {})
+    signed_params = fragment.children.first["data-signed-params"]
+    subscribe
+
+    perform :receive, {"signed_params" => [signed_params]}
+
+    assert renderer_spy.has_been_called_with?(partial: "posts/card", locals: {post: post})
+  end
+
   test "broadcasts a collection" do
     renderer_spy = Spy.on(ApplicationController, :render)
     Post.create title: "Lorem"


### PR DESCRIPTION
It was a tad more involved...

The problem is, we have to pass `locals` explicitly (the shorthand syntax works without such a key), but keep the `html_options` separate.

The solution isn't optimal, there's some duck type lurking here to be extracted, but at least I managed to introduce a test for this.

Please confirm on your end :)